### PR TITLE
Increase the touchable surface area of the toggle button

### DIFF
--- a/src/components/InfoPopup.tsx
+++ b/src/components/InfoPopup.tsx
@@ -48,6 +48,11 @@ const InfoPopup: React.FC = () => {
       borderRadius: 4,
       elevation: 2,
     },
+    toggleButton: {
+      borderWidth: 0,
+      padding: 8,
+      elevation: 2,
+    },
     container: {
       flex: 1,
       justifyContent: 'center',
@@ -95,7 +100,8 @@ const InfoPopup: React.FC = () => {
     infoContainer: {
       flexDirection: 'row',
       width: '100%',
-      padding: 24,
+      paddingHorizontal: 24,
+      paddingVertical: 16,
       justifyContent: 'space-between',
       alignItems: 'center',
       gap: 8,
@@ -177,7 +183,7 @@ const InfoPopup: React.FC = () => {
           <View style={styles.modalView}>
             <View style={styles.infoContainer}>
               <Text style={styles.titleText}>{t('welcomeMessageTitle')}</Text>
-              <Pressable onPress={() => togglePopup()} style={{ borderWidth: 0 }}>
+              <Pressable onPress={() => togglePopup()} style={styles.toggleButton} hitSlop={8}>
                 <CloseIcon fill={theme.primaryColor} hoverFill={theme.hoverColor} style={{ borderWidth: 0 }} />
               </Pressable>
             </View>


### PR DESCRIPTION
After a user logs in, the app displays a welcome message with a dismiss button in the top right corner, the button has extremely small touchable surface area of 14x15 which requires multiple taps on mobile devices to get right.

![before](https://github.com/user-attachments/assets/898a6ff7-95a0-46c7-bfa8-f46a82eac9ec)

This PR adds some padding (web / native) to increase the touchable surface area along with a hit slop (native only) that allows the button to be tapped from outside of its structure. The vertical padding of the surrounding container has been updated to maintain the existing layout.

![image](https://github.com/user-attachments/assets/aa959bc3-41b8-4996-8648-1c77033f6754)

One other thing I have noticed is that there is a sizable vertical gap between the title and body of the popup, not sure if that was done on purpose, it looks like it should be cut by half or so (this PR doesn't address this issue).

![image](https://github.com/user-attachments/assets/5a6f38b1-8c84-42d9-89fa-9f2964fdf4b2)

