### PR TITLE
Fix thread sharing bug

### DIFF
--- a/src/services/ChatService.ts
+++ b/src/services/ChatService.ts
@@ -180,10 +180,14 @@ class ChatService {
   }
 
   async getSharedThread(sharedThreadUUID: string, dispatch: Dispatch<UnknownAction>): Promise<Thread> {
+    // This is a public sharing endpoint which doesn't require an access token
     const response = await fetchWithAuthRetry(
       `${this.baseURL}/share/${sharedThreadUUID}`,
       {
-        headers: this.createHeaders(),
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Mobile-Ansari': 'ANSARI',
+        },
       },
       dispatch,
     )


### PR DESCRIPTION
When registered Ansari users share a thread with others, the final link only works if the user is logged-in, for others it produces 404 as the implementation doesn't allow unauthenticated users to access the share page.

Here is an example (try to open the link without being logged-in).

https://ansari.chat/share/b90f39bd-169d-4a88-b09d-b968e4d64332