### PR TITLE
Configure the Google Play account used by Expo during submissions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ expo-env.d.ts
 ios
 android
 android-keystores
+google-service-account
 *.orig.*
 *.jks
 *.p8

--- a/eas.json
+++ b/eas.json
@@ -30,6 +30,11 @@
     }
   },
   "submit": {
-    "production": {}
+    "production": {
+      "android": {
+        "serviceAccountKeyPath": "./google-service-account/service-account.json",
+        "track": "internal"
+      }
+    }
   }
 }


### PR DESCRIPTION
This PR updates eas.json with the details of the service account that allows Expo to submit builds directly to Google Play.