### PR TITLE
Introduce an option to flag offensive content

### DIFF
--- a/src/components/chat/ReactionButtons.tsx
+++ b/src/components/chat/ReactionButtons.tsx
@@ -1,4 +1,4 @@
-import { CheckIcon, CloseIcon, CopyIcon, DislikeIcon, LikeIcon } from '@/components/svg'
+import { CheckIcon, CloseIcon, CopyIcon, DislikeIcon, FlagIcon, LikeIcon } from '@/components/svg'
 import { useDirection, useFeedbackHandler, useFeedbackService, useScreenInfo } from '@/hooks'
 import { FeedbackClass, Message, ReactionButtonsState, RootState } from '@/store'
 import { createGeneralThemedStyles } from '@/utils'
@@ -86,6 +86,10 @@ const ReactionButtons: React.FC<ReactionButtonsProps> = ({ threadId, messageId, 
       feedbackOptions = feedbacks.bad || []
     }
 
+    if (selectedFeedbackClass === FeedbackClass.RedFlag) {
+      feedbackOptions = feedbacks.redflag || []
+    }
+
     return (
       <View className='flex-row flex-wrap gap-x-2'>
         {feedbackOptions.map((option) => (
@@ -149,6 +153,21 @@ const ReactionButtons: React.FC<ReactionButtonsProps> = ({ threadId, messageId, 
         >
           <DislikeIcon
             fill={selectedIcon === FeedbackClass.ThumbsDown ? theme.hoverColor : theme.iconFill}
+            hoverFill={theme.hoverColor}
+            width={24}
+            height={24}
+          />
+        </Pressable>
+        <Pressable
+          onPress={() => {
+            handleFeedbackAction(FeedbackClass.RedFlag)
+            setEditing(true)
+          }}
+          className={`w-5 h-5 ${isRTL ? 'mr-2' : 'ml-2'}`}
+          hitSlop={8}
+        >
+          <FlagIcon
+            fill={selectedIcon === FeedbackClass.RedFlag ? theme.hoverColor : theme.iconFill}
             hoverFill={theme.hoverColor}
             width={24}
             height={24}

--- a/src/components/svg/FlagIcon.tsx
+++ b/src/components/svg/FlagIcon.tsx
@@ -12,7 +12,8 @@ const FlagIcon: React.FC<Props> = (props: Props) => {
       width={props.width || '24'}
       height={props.height || '24'}
       viewBox={props.viewBox || '0 0 24 24'}
-      fill={props.fill || '#08786B'}
+      fill={props.fill || 'currentColor'}
+      stroke={props.stroke || 'currentColor'}
       transform={props.transform || transform}
     >
       <G>

--- a/src/i18n/locales/ar/feedback.json
+++ b/src/i18n/locales/ar/feedback.json
@@ -18,17 +18,24 @@
   ],
   "bad": [
     {
-      "id": "bad1",
-      "label": "مضارب / غير آمن",
-      "value": "offensive"
-    },
-    {
       "id": "bad2",
       "label": "لا يكون صحيحاً في الواقع",
       "value": "incorrect"
     },
     {
       "id": "bad3",
+      "label": "أخرى",
+      "value": "other"
+    }
+  ],
+  "redflag": [
+    {
+      "id": "redflag1",
+      "label": "مضارب / غير آمن",
+      "value": "offensive"
+    },
+    {
+      "id": "redflag2",
       "label": "أخرى",
       "value": "other"
     }

--- a/src/i18n/locales/bs/feedback.json
+++ b/src/i18n/locales/bs/feedback.json
@@ -18,17 +18,24 @@
   ],
   "bad": [
     {
-      "id": "bad1",
-      "label": "Neprikladno / Neposredno",
-      "value": "offensive"
-    },
-    {
       "id": "bad2",
       "label": "Nepravilno faktično",
       "value": "incorrect"
     },
     {
       "id": "bad3",
+      "label": "Drugo",
+      "value": "other"
+    }
+  ],
+  "redflag": [
+    {
+      "id": "redflag1",
+      "label": "Neprikladno / Neposredno",
+      "value": "offensive"
+    },
+    {
+      "id": "redflag2",
       "label": "Drugo",
       "value": "other"
     }

--- a/src/i18n/locales/en/feedback.json
+++ b/src/i18n/locales/en/feedback.json
@@ -18,17 +18,24 @@
   ],
   "bad": [
     {
-      "id": "bad1",
-      "label": "Offensive / Unsafe",
-      "value": "offensive"
-    },
-    {
       "id": "bad2",
       "label": "Not factually correct",
       "value": "incorrect"
     },
     {
       "id": "bad3",
+      "label": "Other",
+      "value": "other"
+    }
+  ],
+  "redflag": [
+    {
+      "id": "redflag1",
+      "label": "Offensive / Unsafe",
+      "value": "offensive"
+    },
+    {
+      "id": "redflag2",
       "label": "Other",
       "value": "other"
     }

--- a/src/i18n/locales/fr/feedback.json
+++ b/src/i18n/locales/fr/feedback.json
@@ -18,17 +18,24 @@
   ],
   "bad": [
     {
-      "id": "bad1",
-      "label": "Offensif / Dangereux",
-      "value": "offensive"
-    },
-    {
       "id": "bad2",
       "label": "Pas exactement correct",
       "value": "incorrect"
     },
     {
       "id": "bad3",
+      "label": "Autre",
+      "value": "other"
+    }
+  ],
+  "redflag": [
+    {
+      "id": "redflag1",
+      "label": "Offensif / Dangereux",
+      "value": "offensive"
+    },
+    {
+      "id": "redflag2",
       "label": "Autre",
       "value": "other"
     }

--- a/src/i18n/locales/id/feedback.json
+++ b/src/i18n/locales/id/feedback.json
@@ -18,17 +18,24 @@
   ],
   "bad": [
     {
-      "id": "bad1",
-      "label": "Kasar / Tidak aman",
-      "value": "offensive"
-    },
-    {
       "id": "bad2",
       "label": "Tidak benar fakta",
       "value": "incorrect"
     },
     {
       "id": "bad3",
+      "label": "Lainnya",
+      "value": "other"
+    }
+  ],
+  "redflag": [
+    {
+      "id": "redflag1",
+      "label": "Kasar / Tidak aman",
+      "value": "offensive"
+    },
+    {
+      "id": "redflag2",
       "label": "Lainnya",
       "value": "other"
     }

--- a/src/i18n/locales/tml/feedback.json
+++ b/src/i18n/locales/tml/feedback.json
@@ -18,17 +18,24 @@
   ],
   "bad": [
     {
-      "id": "bad1",
-      "label": "அவமதிப்பான/மனத்தை புண்படுத்துகிற/பாதுகாப்பற்ற தகவல் ",
-      "value": "offensive"
-    },
-    {
       "id": "bad2",
       "label": "உண்மையற்றது/தவறான தகவல்",
       "value": "incorrect"
     },
     {
       "id": "bad3",
+      "label": "தவறான தகவல்",
+      "value": "other"
+    }
+  ],
+  "redflag": [
+    {
+      "id": "redflag1",
+      "label": "அவமதிப்பான/மனத்தை புண்படுத்துகிற/பாதுகாப்பற்ற தகவல் ",
+      "value": "offensive"
+    },
+    {
+      "id": "redflag2",
       "label": "தவறான தகவல்",
       "value": "other"
     }

--- a/src/i18n/locales/tur/feedback.json
+++ b/src/i18n/locales/tur/feedback.json
@@ -18,17 +18,24 @@
   ],
   "bad": [
     {
-      "id": "bad1",
-      "label": "Saldırgan / Tehlikeli",
-      "value": "offensive"
-    },
-    {
       "id": "bad2",
       "label": "Tamamen Doğru Değil",
       "value": "incorrect"
     },
     {
       "id": "bad3",
+      "label": "Diğer",
+      "value": "other"
+    }
+  ],
+  "redflag": [
+    {
+      "id": "redflag1",
+      "label": "Saldırgan / Tehlikeli",
+      "value": "offensive"
+    },
+    {
+      "id": "redflag2",
       "label": "Diğer",
       "value": "other"
     }

--- a/src/i18n/locales/ur/feedback.json
+++ b/src/i18n/locales/ur/feedback.json
@@ -18,17 +18,24 @@
   ],
   "bad": [
     {
-      "id": "bad1",
-      "label": "توہین آمیز / نا محفوظ",
-      "value": "offensive"
-    },
-    {
       "id": "bad2",
       "label": "حقائقی طور پر غلط",
       "value": "incorrect"
     },
     {
       "id": "bad3",
+      "label": "دیگر",
+      "value": "other"
+    }
+  ],
+  "redflag": [
+    {
+      "id": "redflag1",
+      "label": "توہین آمیز / نا محفوظ",
+      "value": "offensive"
+    },
+    {
+      "id": "redflag2",
       "label": "دیگر",
       "value": "other"
     }

--- a/src/services/FeedbackService.ts
+++ b/src/services/FeedbackService.ts
@@ -17,6 +17,7 @@ export type Feedback = {
 export type FeedbacksByCategory = {
   good: Feedback[]
   bad: Feedback[]
+  redflag: Feedback[]
   [key: string]: Feedback[]
 }
 


### PR DESCRIPTION
This option introduces content flagging that is primarily introduced for compliance with Google Play.

I have basically moved the Offensive / Unsafe option from the thumbsdown section to a standalone flagging section.

Thumbs down:
<img width="331" alt="image" src="https://github.com/user-attachments/assets/eae6041f-30e3-420c-ae2e-c4fa88d0e7a2" />

Flag:
<img width="335" alt="image" src="https://github.com/user-attachments/assets/3f95e08c-53f7-4290-8fed-95555be9bd47" />