### PR TITLE
Resolve scrolling issue

### DIFF
--- a/src/components/chat/MessageBubble.tsx
+++ b/src/components/chat/MessageBubble.tsx
@@ -80,7 +80,6 @@ const MessageBubble: React.FC<MessageBubbleProps> = ({
   return (
     <View
       className={`mx-1 my-1 rounded flex flex-row flex-grow self-start ${isSmallScreen ? 'p-2 gap-2' : 'p-2.5 gap-4'}`}
-      style={{ width: width || contentWidth }}
     >
       {isOutgoing ? (
         <View className='rounded px-5 py-2 w-8 h-8 items-center justify-center'>


### PR DESCRIPTION
I had a look at the issue that Marci raised, basically in desktop mode when the side panel is displayed, the conversation history was set to to utilise a width that is larger than the available space in the viewport resulting in a horizontal spacebar (with some content hidden).

I have removed the explicit width setting and relied on the existing flex-grow option which will fill the available space without spilling over.

The setting value of 'width || contentWidth' also doesn't make sense as width will always have a value, I have tested the update on web, Android and iOS and it's looking good.