### PR TITLE
Integrate Vercel analytics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@react-navigation/native": "^7.0.14",
         "@reduxjs/toolkit": "^2.1.0",
         "@sentry/react-native": "~6.9.1",
+        "@vercel/analytics": "^1.5.0",
         "dotenv": "^16.4.5",
         "expo": "~52.0.38",
         "expo-application": "~6.0.2",
@@ -5459,6 +5460,44 @@
       },
       "peerDependencies": {
         "@urql/core": "^5.0.0"
+      }
+    },
+    "node_modules/@vercel/analytics": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-1.5.0.tgz",
+      "integrity": "sha512-MYsBzfPki4gthY5HnYN7jgInhAZ7Ac1cYDoRWFomwGHWEX7odTEzbtg9kf/QSo7XEsEAqlQugA6gJ2WS2DEa3g==",
+      "license": "MPL-2.0",
+      "peerDependencies": {
+        "@remix-run/react": "^2",
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@remix-run/react": {
+          "optional": true
+        },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
       }
     },
     "node_modules/@webassemblyjs/ast": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@react-navigation/native": "^7.0.14",
     "@reduxjs/toolkit": "^2.1.0",
     "@sentry/react-native": "~6.9.1",
+    "@vercel/analytics": "^1.5.0",
     "dotenv": "^16.4.5",
     "expo": "~52.0.38",
     "expo-application": "~6.0.2",
@@ -29,6 +30,7 @@
     "expo-screen-orientation": "~8.0.4",
     "expo-splash-screen": "~0.29.22",
     "expo-status-bar": "~2.0.1",
+    "expo-store-review": "~8.0.1",
     "expo-symbols": "~0.2.1",
     "expo-system-ui": "~4.0.8",
     "expo-updates": "~0.27.3",
@@ -58,8 +60,7 @@
     "redux-first-history": "^5.2.0",
     "redux-thunk": "^3.1.0",
     "web-vitals": "^2.1.4",
-    "yup": "^1.3.3",
-    "expo-store-review": "~8.0.1"
+    "yup": "^1.3.3"
   },
   "scripts": {
     "start": "expo start",

--- a/src/components/RootContainer.web.tsx
+++ b/src/components/RootContainer.web.tsx
@@ -1,6 +1,9 @@
 import React, { useEffect } from 'react'
 import { i18n } from '@/i18n'
 import { View } from 'react-native'
+import { inject } from '@vercel/analytics'
+
+inject()
 
 export type Props = {
   children: React.ReactNode


### PR DESCRIPTION
This PR integrates the Vercel analytics client library into the web build, the implementation is slightly different from the official React approach as the official approach isn't compatible with Metro, this variation should work as expected but I would like to test it in the staging environment first before we promote it to production.