### PR TITLE
#57 Clear the question after send

### DIFF
--- a/src/hooks/chat/useChat.ts
+++ b/src/hooks/chat/useChat.ts
@@ -60,6 +60,7 @@ export function useChat(): UseChatReturn {
         }
       }
       if (threadId && content.trim()) {
+        setInputText('') // Clear input text immediately
         await dispatch(
           addMessage({
             threadId: threadId,
@@ -74,7 +75,6 @@ export function useChat(): UseChatReturn {
       setIsSending(false)
       return { threadId: undefined, error } // Include error feedback
     } finally {
-      setInputText('') // Clear input text on successful send
       setIsSending(false)
       abortControllerRef.current = null
     }


### PR DESCRIPTION
For better UX, clearing the text after a question has been submitted. This is inline with all other AI Chat experience (Claude, ChatGPT). This allows the user to start typing his next question while the answer is being revealed.


**Before:**

https://github.com/user-attachments/assets/abb8f330-d42d-4721-b147-aac389ad8505



**After:**

https://github.com/user-attachments/assets/a285d2d1-5341-44b1-83c4-260527c29c23

