### PR TITLE
Fix feedback 422 on freshly streamed messages

### DIFF
--- a/src/store/actions/chatActions.ts
+++ b/src/store/actions/chatActions.ts
@@ -70,6 +70,13 @@ export const addMessage = createAsyncThunk(
           content: responseMessage,
           timestamp: new Date().getTime().toString(),
         }
+        // Reconcile client-generated ids with the server's message UUIDs.
+        // Streamed messages carry Helpers.generateUniqueId() placeholders, which
+        // POST /api/v2/feedback rejects (422: z.string().uuid()). The backend
+        // persists the assistant message before closing the stream, so refetching
+        // here returns the completed turn with real ids — the same pattern the
+        // chat screen already uses on mount (app/(app)/chat/[threadId].tsx).
+        await dispatch(fetchThread(threadId))
         return message
       } catch (error) {
         dispatch(setError('Error adding message ' + error))


### PR DESCRIPTION
Thumbs-down (and all feedback) on a just-streamed answer silently fails: the client fabricates message ids (`Helpers.generateUniqueId()`, 32 alphanumerics), and `POST /api/v2/feedback` validates `z.string().uuid()` → 422, swallowed by `sendFeedback`'s catch.

**Fix**: after the stream completes in the `addMessage` thunk, dispatch the existing `fetchThread(threadId)` — the GET returns real server UUIDs and `setActiveThread` reconciles the store. Same pattern the chat screen already uses on mount (`app/(app)/chat/[threadId].tsx`). No API change; the backend persists the assistant message before closing the stream, so there is no race.

**Verification**: 62/62 jest tests pass. The two bare-`tsc` errors in this file are pre-existing at the `multisage` baseline (no typecheck script in this repo).

Production evidence: only 36% of feedback lands within 2 min of the rated message, and thumbs_down (given on fresh answers) totals 68 all-time vs 683 thumbs_up. Interim fix while iaser-ai/ansari#75 ports this app into the monorepo.