### PR TITLE
Fix #77: feedback detail panel never appeared — sendFeedback unmounted the message list mid-click

### DIFF
--- a/codev/projects/bugfix-77-feedback-detail-panel-never-ap/status.yaml
+++ b/codev/projects/bugfix-77-feedback-detail-panel-never-ap/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-77
 title: feedback-detail-panel-never-ap
 protocol: bugfix
-phase: pr
+phase: verified
 plan_phases: []
 current_plan_phase: null
 gates: {}
@@ -9,4 +9,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-30T05:59:43.975Z'
-updated_at: '2026-08-30T06:03:12.404Z'
+updated_at: '2026-08-30T06:12:22.735Z'

--- a/codev/projects/bugfix-77-feedback-detail-panel-never-ap/status.yaml
+++ b/codev/projects/bugfix-77-feedback-detail-panel-never-ap/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-77
 title: feedback-detail-panel-never-ap
 protocol: bugfix
-phase: fix
+phase: pr
 plan_phases: []
 current_plan_phase: null
 gates: {}
@@ -9,4 +9,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-30T05:59:43.975Z'
-updated_at: '2026-08-30T06:00:26.028Z'
+updated_at: '2026-08-30T06:03:12.404Z'

--- a/codev/projects/bugfix-77-feedback-detail-panel-never-ap/status.yaml
+++ b/codev/projects/bugfix-77-feedback-detail-panel-never-ap/status.yaml
@@ -1,0 +1,12 @@
+id: bugfix-77
+title: feedback-detail-panel-never-ap
+protocol: bugfix
+phase: investigate
+plan_phases: []
+current_plan_phase: null
+gates: {}
+iteration: 1
+build_complete: false
+history: []
+started_at: '2026-08-30T05:59:43.975Z'
+updated_at: '2026-08-30T05:59:43.976Z'

--- a/codev/projects/bugfix-77-feedback-detail-panel-never-ap/status.yaml
+++ b/codev/projects/bugfix-77-feedback-detail-panel-never-ap/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-77
 title: feedback-detail-panel-never-ap
 protocol: bugfix
-phase: investigate
+phase: fix
 plan_phases: []
 current_plan_phase: null
 gates: {}
@@ -9,4 +9,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-30T05:59:43.975Z'
-updated_at: '2026-08-30T05:59:43.976Z'
+updated_at: '2026-08-30T06:00:26.028Z'

--- a/src/components/chat/ReactionButtons.tsx
+++ b/src/components/chat/ReactionButtons.tsx
@@ -150,7 +150,7 @@ const ReactionButtons: React.FC<ReactionButtonsProps> = ({ threadId, messageId, 
         </Pressable>
       </View>
       {modalVisible && (
-        <View className={`w-full h-0 mt-6 ${modalVisible ? 'h-auto' : ''}`}>
+        <View className='w-full mt-6'>
           <View
             className='w-full px-2 sm:px-5 py-4 items-start rounded'
             style={{ backgroundColor: theme.inputBackgroundColor }}

--- a/src/services/FeedbackService.ts
+++ b/src/services/FeedbackService.ts
@@ -40,7 +40,7 @@ const fetchFeedbacksForLanguage = async (language: string): Promise<FeedbacksByC
   }
 
   // Region-tagged locales (e.g. 'en-US', 'ar-EG') must resolve to their base language
-  const baseLanguage = language.split('-')[0]
+  const baseLanguage = (language || '').split('-')[0]
 
   return data[baseLanguage] || data.en // Default to English if language not found
 }

--- a/src/services/FeedbackService.ts
+++ b/src/services/FeedbackService.ts
@@ -39,7 +39,10 @@ const fetchFeedbacksForLanguage = async (language: string): Promise<FeedbacksByC
     ur: urFeedback,
   }
 
-  return data[language] || data.en // Default to English if language not found
+  // Region-tagged locales (e.g. 'en-US', 'ar-EG') must resolve to their base language
+  const baseLanguage = language.split('-')[0]
+
+  return data[baseLanguage] || data.en // Default to English if language not found
 }
 
 export default fetchFeedbacksForLanguage

--- a/src/services/FeedbackService.ts
+++ b/src/services/FeedbackService.ts
@@ -42,7 +42,12 @@ const fetchFeedbacksForLanguage = async (language: string): Promise<FeedbacksByC
   // Region-tagged locales (e.g. 'en-US', 'ar-EG') must resolve to their base language
   const baseLanguage = (language || '').split('-')[0]
 
-  return data[baseLanguage] || data.en // Default to English if language not found
+  // Our locale keys use nonstandard codes for Turkish and Tamil, while devices
+  // and i18n report the ISO codes — map those onto our keys before the lookup
+  const localeAliases: { [key: string]: string } = { tr: 'tur', ta: 'tml' }
+  const localeKey = localeAliases[baseLanguage] || baseLanguage
+
+  return data[localeKey] || data.en // Default to English if language not found
 }
 
 export default fetchFeedbacksForLanguage

--- a/src/services/PromptsService.ts
+++ b/src/services/PromptsService.ts
@@ -41,7 +41,15 @@ const fetchPromptsForLanguage = async (language: string): Promise<PromptsByCateg
     ur: urPrompts,
   }
 
-  const promptsByLanguage = data[language] || data.en // Default to English if language not found
+  // Region-tagged locales (e.g. 'en-US', 'ar-EG') must resolve to their base language
+  const baseLanguage = (language || '').split('-')[0]
+
+  // Our locale keys use nonstandard codes for Turkish and Tamil, while devices
+  // and i18n report the ISO codes — map those onto our keys before the lookup
+  const localeAliases: { [key: string]: string } = { tr: 'tur', ta: 'tml' }
+  const localeKey = localeAliases[baseLanguage] || baseLanguage
+
+  const promptsByLanguage = data[localeKey] || data.en // Default to English if language not found
 
   // Initialize an empty object to store one random prompt per category
   const randomPrompts: PromptsByCategory = { dua: [], perspectives: [], remedies: [] }

--- a/src/services/__tests__/FeedbackService.test.ts
+++ b/src/services/__tests__/FeedbackService.test.ts
@@ -1,0 +1,23 @@
+import fetchFeedbacksForLanguage from '../FeedbackService'
+
+describe('fetchFeedbacksForLanguage', () => {
+  it('resolves region-tagged locales to their base language (issue #77)', async () => {
+    const arabic = await fetchFeedbacksForLanguage('ar')
+    const english = await fetchFeedbacksForLanguage('en')
+    expect(arabic).not.toBe(english)
+
+    expect(await fetchFeedbacksForLanguage('ar-EG')).toBe(arabic)
+    expect(await fetchFeedbacksForLanguage('en-US')).toBe(english)
+  })
+
+  it('returns the exact match for base language codes', async () => {
+    const turkish = await fetchFeedbacksForLanguage('tur')
+    expect(turkish.good).toBeDefined()
+    expect(turkish.bad).toBeDefined()
+  })
+
+  it('falls back to English for unknown languages', async () => {
+    const english = await fetchFeedbacksForLanguage('en')
+    expect(await fetchFeedbacksForLanguage('xx')).toBe(english)
+  })
+})

--- a/src/services/__tests__/FeedbackService.test.ts
+++ b/src/services/__tests__/FeedbackService.test.ts
@@ -16,6 +16,19 @@ describe('fetchFeedbacksForLanguage', () => {
     expect(turkish.bad).toBeDefined()
   })
 
+  it('maps ISO codes to our nonstandard Turkish and Tamil locale keys', async () => {
+    const turkish = await fetchFeedbacksForLanguage('tur')
+    const tamil = await fetchFeedbacksForLanguage('tml')
+    const english = await fetchFeedbacksForLanguage('en')
+    expect(turkish).not.toBe(english)
+    expect(tamil).not.toBe(english)
+
+    expect(await fetchFeedbacksForLanguage('tr')).toBe(turkish)
+    expect(await fetchFeedbacksForLanguage('tr-TR')).toBe(turkish)
+    expect(await fetchFeedbacksForLanguage('ta')).toBe(tamil)
+    expect(await fetchFeedbacksForLanguage('ta-IN')).toBe(tamil)
+  })
+
   it('falls back to English for unknown or missing languages', async () => {
     const english = await fetchFeedbacksForLanguage('en')
     expect(await fetchFeedbacksForLanguage('xx')).toBe(english)

--- a/src/services/__tests__/FeedbackService.test.ts
+++ b/src/services/__tests__/FeedbackService.test.ts
@@ -16,8 +16,9 @@ describe('fetchFeedbacksForLanguage', () => {
     expect(turkish.bad).toBeDefined()
   })
 
-  it('falls back to English for unknown languages', async () => {
+  it('falls back to English for unknown or missing languages', async () => {
     const english = await fetchFeedbacksForLanguage('en')
     expect(await fetchFeedbacksForLanguage('xx')).toBe(english)
+    expect(await fetchFeedbacksForLanguage(undefined as unknown as string)).toBe(english)
   })
 })

--- a/src/services/__tests__/PromptsService.test.ts
+++ b/src/services/__tests__/PromptsService.test.ts
@@ -1,0 +1,20 @@
+import turPrompts from '@/i18n/locales/tur/prompts.json'
+import tmlPrompts from '@/i18n/locales/tml/prompts.json'
+import enPrompts from '@/i18n/locales/en/prompts.json'
+import fetchPromptsForLanguage from '../PromptsService'
+
+describe('fetchPromptsForLanguage', () => {
+  // Prompt ids are shared across locales, so compare the localized titles
+  const turkishTitles = turPrompts.dua.map((prompt) => prompt.title)
+  const tamilTitles = tmlPrompts.dua.map((prompt) => prompt.title)
+  const englishTitles = enPrompts.dua.map((prompt) => prompt.title)
+
+  it('maps ISO codes and region tags to our nonstandard locale keys (issue #77)', async () => {
+    expect(turkishTitles).not.toEqual(englishTitles)
+
+    expect(turkishTitles).toContain((await fetchPromptsForLanguage('tr')).dua[0].title)
+    expect(turkishTitles).toContain((await fetchPromptsForLanguage('tr-TR')).dua[0].title)
+    expect(turkishTitles).toContain((await fetchPromptsForLanguage('tur')).dua[0].title)
+    expect(tamilTitles).toContain((await fetchPromptsForLanguage('ta')).dua[0].title)
+  })
+})

--- a/src/store/actions/__tests__/chatActions.sendFeedback.test.ts
+++ b/src/store/actions/__tests__/chatActions.sendFeedback.test.ts
@@ -1,0 +1,62 @@
+import { sendFeedback } from '@/store/actions/chatActions'
+import { setError, setLoading } from '@/store/slices/chatSlice'
+import { FeedbackClass, FeedbackRequest } from '@/store/types/chatTypes'
+
+const mockSendFeedback = jest.fn()
+
+jest.mock('@/services/', () => ({
+  ChatService: jest.fn().mockImplementation(() => ({
+    sendFeedback: (...args: unknown[]) => mockSendFeedback(...args),
+  })),
+}))
+
+const feedbackRequest: FeedbackRequest = {
+  threadId: 'thread-1',
+  messageId: 'message-1',
+  feedbackClass: FeedbackClass.ThumbsDown,
+  comment: 'Not comprehensive - missing citations',
+}
+
+const runSendFeedbackThunk = async (): Promise<jest.Mock> => {
+  const dispatch = jest.fn()
+  const getState = jest.fn(() => ({ auth: { isAuthenticated: true, accessToken: 'token' } }))
+  await sendFeedback({ feedbackRequest })(dispatch, getState, undefined)
+  return dispatch
+}
+
+const dispatchedTypes = (dispatch: jest.Mock): string[] => dispatch.mock.calls.map(([action]) => action?.type)
+
+describe('sendFeedback thunk', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('does not toggle the global chat loading flag (issue #77)', async () => {
+    mockSendFeedback.mockResolvedValueOnce(undefined)
+    const dispatch = await runSendFeedbackThunk()
+
+    expect(dispatchedTypes(dispatch)).not.toContain(setLoading(true).type)
+  })
+
+  it('sends the feedback payload to ChatService', async () => {
+    mockSendFeedback.mockResolvedValueOnce(undefined)
+    await runSendFeedbackThunk()
+
+    expect(mockSendFeedback).toHaveBeenCalledWith(
+      'thread-1',
+      'message-1',
+      FeedbackClass.ThumbsDown,
+      'Not comprehensive - missing citations',
+      expect.any(Function),
+    )
+  })
+
+  it('dispatches setError on failure without toggling the loading flag', async () => {
+    mockSendFeedback.mockRejectedValueOnce(new Error('network down'))
+    const dispatch = await runSendFeedbackThunk()
+
+    const types = dispatchedTypes(dispatch)
+    expect(types).toContain(setError('').type)
+    expect(types).not.toContain(setLoading(true).type)
+  })
+})

--- a/src/store/actions/chatActions.ts
+++ b/src/store/actions/chatActions.ts
@@ -299,7 +299,9 @@ export const sendFeedback = createAsyncThunk(
     try {
       const { isAuthenticated, accessToken } = (getState() as RootState).auth
       const chatService = new ChatService(isAuthenticated, accessToken)
-      dispatch(setLoading(true))
+      // Never toggle the global chat.loading flag here: it swaps MessageList for a
+      // full-screen spinner, unmounting ReactionButtons and losing the feedback
+      // detail panel's local state mid-click (issue #77).
       await chatService.sendFeedback(
         feedbackRequest.threadId,
         feedbackRequest.messageId,
@@ -307,11 +309,8 @@ export const sendFeedback = createAsyncThunk(
         feedbackRequest.comment,
         dispatch,
       )
-      // dispatch(setFeedback) // refresh the list of threads after deletion
     } catch (error) {
       dispatch(setError(error.toString()))
-    } finally {
-      dispatch(setLoading(false))
     }
   },
 )


### PR DESCRIPTION
## Summary

Clicking thumbs-up/down recorded the feedback row and highlighted the icon, but the detail panel (option chips + comment box) never appeared — which is why nearly all feedback rows have empty comments. The `sendFeedback` thunk was toggling the global `chat.loading` flag, replacing the entire message list with a spinner mid-click and destroying the panel's local state.

Fixes #77

## Root Cause

1. Thumb click → `handleFeedbackAction` → `dispatch(sendFeedback)` → `dispatch(setLoading(true))` on the **global** `chat.loading` flag.
2. `MessageList` returns a full-screen `ActivityIndicator` when `isLoading && !isSending`, unmounting every `ReactionButtons`.
3. The `setModalVisible(true)` from the same click lands on the unmounting component and is lost; when the POST completes and the list remounts, `modalVisible` is back to `false`. The icon highlight survived only because it lives in Redux.

## Fix

- `src/store/actions/chatActions.ts`: `sendFeedback` no longer dispatches `setLoading(true/false)` — a feedback POST needs no full-screen spinner. All other thunks keep their loading behavior; `chatSlice` has no `extraReducers`, so no residual path sets the flag.
- `src/services/FeedbackService.ts`: normalize region-tagged locales (`en-US`, `ar-EG`) to their base language, then map ISO codes onto our nonstandard locale keys (`tr→tur`, `ta→tml`) so Turkish and Tamil users get their language's chips instead of silently falling back to English. Guarded against undefined locale (preserves the English fallback).
- `src/services/PromptsService.ts`: same normalization + aliasing — it had the identical bare `data[language]` lookup against `tur`/`tml` keys.
- `src/components/chat/ReactionButtons.tsx`: drop the dead `h-0`/`h-auto` class conflict on the panel container (block only renders when visible).

## Scope decision: double-POST accepted as-is (issue #77)

Reviewers flagged that a thumb click POSTs `comment: ''` immediately and the panel submit POSTs a second row, so empty-comment rows persist. **Backend decision (relayed by architect 2026-08-30): zero API change — the current two-POST behavior is accepted.** Duplicate rows are the backend's to dedupe in analytics ("prefer non-empty comment, else latest"). No frontend change; a sendBeacon-on-pagehide variant was considered and declined as unnecessary complexity.

## Known pre-existing issues (out of scope, noted for the record)

- `i18n.ts` initializes `lng` from the device's ISO `languageCode` while translation resources are keyed `tur`/`tml`, so full-UI translations for Turkish/Tamil devices likely also fall back to English — broader than this PR (touches i18n init + stored preferences).
- `ChatService.sendFeedback` swallows all errors (never throws, even on `!response.ok`), so feedback POST failures are silent to the user.
- `setEditing` is never reset on submit in `ReactionButtons`, so the comment box autofocus won't re-fire on a second thumb click.

## Test Plan

- [x] Regression tests — `chatActions.sendFeedback.test.ts` asserts the thunk dispatches no `setLoading` action (verified failing pre-fix) and still posts the payload; `FeedbackService.test.ts` covers region-tag normalization, `tr`/`tr-TR`/`ta`/`ta-IN` aliasing, unchanged `tur`/`tml` keys, and the English fallback; `PromptsService.test.ts` covers the same aliasing (all verified failing pre-fix)
- [x] Build passes (`expo export --platform web`)
- [x] All tests pass (9 suites, 39 tests)

## CMAP

Round 1: gemini=APPROVE, codex=REQUEST_CHANGES, claude=REQUEST_CHANGES (wrong base branch — retargeted `main`→`multisage`).
Round 2: gemini=APPROVE, codex=APPROVE, claude=APPROVE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jz3eEbyGv8a3js7u9PRFmt