### PR TITLE
Fix #79: add Cache-Control headers and 404 missing hashed assets in Caddyfile

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,24 +1,24 @@
 :{$PORT:8080} {
-    root * {$SITE_ROOT:/usr/share/caddy}
-    encode gzip
+	root * {$SITE_ROOT:/usr/share/caddy}
+	encode gzip
 
-    # Hashed build output (content-addressed filenames): cache forever.
-    # A missing file here must 404, never fall back to index.html —
-    # otherwise a bundle from a previous deploy is served as HTML and the
-    # browser fails with "Unexpected token '<'".
-    @assets path /_expo/* /assets/*
-    handle @assets {
-        @existing file
-        header @existing Cache-Control "public, max-age=31536000, immutable"
-        file_server
-    }
+	# Hashed build output (content-addressed filenames): cache forever.
+	# A missing file here must 404, never fall back to index.html —
+	# otherwise a bundle from a previous deploy is served as HTML and the
+	# browser fails with "Unexpected token '<'".
+	@assets path /_expo/* /assets/*
+	handle @assets {
+		@existing file
+		header @existing Cache-Control "public, max-age=31536000, immutable"
+		file_server
+	}
 
-    # index.html and everything else: browsers may cache but must
-    # revalidate (etag makes that a cheap 304), so a new deploy is picked
-    # up on the next load instead of after a hard refresh.
-    handle {
-        header Cache-Control "no-cache"
-        try_files {path} /index.html
-        file_server
-    }
+	# index.html and everything else: browsers may cache but must
+	# revalidate (etag makes that a cheap 304), so a new deploy is picked
+	# up on the next load instead of after a hard refresh.
+	handle {
+		header Cache-Control "no-cache"
+		try_files {path} /index.html
+		file_server
+	}
 }

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,6 +1,24 @@
 :{$PORT:8080} {
-    root * /usr/share/caddy
+    root * {$SITE_ROOT:/usr/share/caddy}
     encode gzip
-    file_server
-    try_files {path} /index.html
+
+    # Hashed build output (content-addressed filenames): cache forever.
+    # A missing file here must 404, never fall back to index.html —
+    # otherwise a bundle from a previous deploy is served as HTML and the
+    # browser fails with "Unexpected token '<'".
+    @assets path /_expo/* /assets/*
+    handle @assets {
+        @existing file
+        header @existing Cache-Control "public, max-age=31536000, immutable"
+        file_server
+    }
+
+    # index.html and everything else: browsers may cache but must
+    # revalidate (etag makes that a cheap 304), so a new deploy is picked
+    # up on the next load instead of after a hard refresh.
+    handle {
+        header Cache-Control "no-cache"
+        try_files {path} /index.html
+        file_server
+    }
 }

--- a/codev/projects/bugfix-79-stale-cached-html-breaks-the-s/status.yaml
+++ b/codev/projects/bugfix-79-stale-cached-html-breaks-the-s/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-79
 title: stale-cached-html-breaks-the-s
 protocol: bugfix
-phase: pr
+phase: verified
 plan_phases: []
 current_plan_phase: null
 gates: {}
@@ -9,4 +9,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-31T03:00:09.248Z'
-updated_at: '2026-08-31T03:02:45.207Z'
+updated_at: '2026-08-31T03:10:10.251Z'

--- a/codev/projects/bugfix-79-stale-cached-html-breaks-the-s/status.yaml
+++ b/codev/projects/bugfix-79-stale-cached-html-breaks-the-s/status.yaml
@@ -1,0 +1,12 @@
+id: bugfix-79
+title: stale-cached-html-breaks-the-s
+protocol: bugfix
+phase: investigate
+plan_phases: []
+current_plan_phase: null
+gates: {}
+iteration: 1
+build_complete: false
+history: []
+started_at: '2026-08-31T03:00:09.248Z'
+updated_at: '2026-08-31T03:00:09.249Z'

--- a/codev/projects/bugfix-79-stale-cached-html-breaks-the-s/status.yaml
+++ b/codev/projects/bugfix-79-stale-cached-html-breaks-the-s/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-79
 title: stale-cached-html-breaks-the-s
 protocol: bugfix
-phase: fix
+phase: pr
 plan_phases: []
 current_plan_phase: null
 gates: {}
@@ -9,4 +9,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-31T03:00:09.248Z'
-updated_at: '2026-08-31T03:02:02.715Z'
+updated_at: '2026-08-31T03:02:45.207Z'

--- a/codev/projects/bugfix-79-stale-cached-html-breaks-the-s/status.yaml
+++ b/codev/projects/bugfix-79-stale-cached-html-breaks-the-s/status.yaml
@@ -1,7 +1,7 @@
 id: bugfix-79
 title: stale-cached-html-breaks-the-s
 protocol: bugfix
-phase: investigate
+phase: fix
 plan_phases: []
 current_plan_phase: null
 gates: {}
@@ -9,4 +9,4 @@ iteration: 1
 build_complete: false
 history: []
 started_at: '2026-08-31T03:00:09.248Z'
-updated_at: '2026-08-31T03:00:09.249Z'
+updated_at: '2026-08-31T03:02:02.715Z'

--- a/scripts/check-cache-headers.sh
+++ b/scripts/check-cache-headers.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Verify the Caddy cache/fallback behaviour from issue #79.
+#
+# Usage:
+#   scripts/check-cache-headers.sh [BASE_URL]      (default: https://askansari.ai)
+#
+# Checks:
+#   - /                      -> 200 text/html, Cache-Control: no-cache
+#   - /chat/<id> deep link   -> 200 text/html, Cache-Control: no-cache
+#   - current entry bundle   -> 200 javascript, Cache-Control immutable + 1y max-age
+#   - nonexistent bundle     -> 404, not text/html, no immutable cache header
+set -u
+
+BASE="${1:-https://askansari.ai}"
+BASE="${BASE%/}"
+fail=0
+
+headers() { curl -sSI "$1"; }
+field() { printf '%s\n' "$1" | awk -v k="$2" 'tolower($1)==tolower(k)":" { sub(/^[^:]+:[[:space:]]*/, ""); sub(/\r$/, ""); print; exit }'; }
+status() { printf '%s\n' "$1" | awk 'NR==1 { print $2 }'; }
+
+check() {
+  local label="$1" ok="$2" detail="$3"
+  if [ "$ok" = 1 ]; then
+    echo "PASS  $label"
+  else
+    echo "FAIL  $label  ($detail)"
+    fail=1
+  fi
+}
+
+# Root: SPA HTML, must revalidate.
+h=$(headers "$BASE/")
+check "GET / is 200 HTML" "$( [ "$(status "$h")" = 200 ] && [[ "$(field "$h" content-type)" == text/html* ]] && echo 1 || echo 0 )" "$(status "$h") $(field "$h" content-type)"
+check "GET / has Cache-Control: no-cache" "$( [ "$(field "$h" cache-control)" = "no-cache" ] && echo 1 || echo 0 )" "cache-control='$(field "$h" cache-control)'"
+
+# Deep link: SPA fallback still works.
+h=$(headers "$BASE/chat/issue-79-deep-link")
+check "GET /chat/<id> is 200 HTML" "$( [ "$(status "$h")" = 200 ] && [[ "$(field "$h" content-type)" == text/html* ]] && echo 1 || echo 0 )" "$(status "$h") $(field "$h" content-type)"
+check "GET /chat/<id> has Cache-Control: no-cache" "$( [ "$(field "$h" cache-control)" = "no-cache" ] && echo 1 || echo 0 )" "cache-control='$(field "$h" cache-control)'"
+
+# Current bundle: discover it from index.html, expect immutable caching.
+entry=$(curl -sS "$BASE/" | grep -oE '/_expo/static/js/web/entry-[A-Za-z0-9]+\.js' | head -1)
+if [ -z "$entry" ]; then
+  check "discover entry bundle from index.html" 0 "no /_expo/static/js/web/entry-*.js in HTML"
+else
+  h=$(headers "$BASE$entry")
+  cc=$(field "$h" cache-control)
+  check "GET $entry is 200 JS" "$( [ "$(status "$h")" = 200 ] && [[ "$(field "$h" content-type)" == *javascript* ]] && echo 1 || echo 0 )" "$(status "$h") $(field "$h" content-type)"
+  check "GET $entry is immutable, max-age=31536000" "$( [[ "$cc" == *immutable* && "$cc" == *max-age=31536000* ]] && echo 1 || echo 0 )" "cache-control='$cc'"
+fi
+
+# Stale bundle from an old deploy: must 404, must not be HTML, must not be cached forever.
+h=$(headers "$BASE/_expo/static/js/web/entry-00000000000000000000000000000000.js")
+cc=$(field "$h" cache-control)
+check "GET nonexistent entry bundle is 404" "$( [ "$(status "$h")" = 404 ] && echo 1 || echo 0 )" "status=$(status "$h")"
+check "GET nonexistent entry bundle is not HTML" "$( [[ "$(field "$h" content-type)" != text/html* ]] && echo 1 || echo 0 )" "content-type='$(field "$h" content-type)'"
+check "GET nonexistent entry bundle is not immutable" "$( [[ "$cc" != *immutable* ]] && echo 1 || echo 0 )" "cache-control='$cc'"
+
+# Same for /assets/*.
+h=$(headers "$BASE/assets/does-not-exist.00000000.png")
+check "GET nonexistent /assets file is 404" "$( [ "$(status "$h")" = 404 ] && echo 1 || echo 0 )" "status=$(status "$h")"
+
+exit $fail


### PR DESCRIPTION
## Summary

After every deploy to askansari.ai, returning visitors got a blank page with `Uncaught SyntaxError: Unexpected token '<'` until they hard-refreshed. The Caddyfile now sends proper `Cache-Control` headers and returns 404 (instead of `index.html`) for missing hashed bundles.

Fixes #79

## Root Cause

Verified against live askansari.ai before the fix:

1. The Caddyfile sent no `Cache-Control` header at all, so browsers applied heuristic caching to `index.html` and could serve a days-old copy without revalidating.
2. `try_files {path} /index.html` applied to every path, so a request for an old deploy's `/_expo/static/js/web/entry-<hash>.js` (deleted when the Railway image was replaced) returned **200 `text/html`**. The browser executed the HTML as JS → `Unexpected token '<'`.

## Fix

Caddyfile only, no app code:

- `handle /_expo/*` + `handle /assets/*` (via one `@assets` matcher): bare `file_server`, no SPA fallback, so missing files 404. Existing files get `Cache-Control: public, max-age=31536000, immutable` (the `@existing file` matcher ensures a 404 never carries `immutable`).
- Default `handle` (index.html and deep links like `/chat/<id>`): `Cache-Control: no-cache` — browser may cache but must revalidate; the existing etag makes that a cheap 304.
- `root` is now `{$SITE_ROOT:/usr/share/caddy}` so the config can be run locally against a `dist` build; production behaviour is unchanged.

`caddy validate --config Caddyfile --adapter caddyfile` → `Valid configuration` (caddy v2.11.4).

## Regression test

Jest cannot exercise Caddy, so the test is `scripts/check-cache-headers.sh [BASE_URL]`, which runs the issue's curl acceptance checklist (root + deep link `no-cache` HTML, current bundle immutable JS, nonexistent bundle/asset → 404 and not HTML) and exits non-zero on any failure.

- Against **current production** (old config): 6 of 10 checks FAIL — exactly the two root causes above.
- Against a **local caddy** (`PORT=18080 SITE_ROOT=$PWD/dist caddy run --config Caddyfile --adapter caddyfile`) serving the real `npm run build` output with the new Caddyfile: 10/10 PASS.

## Test Plan

- [x] Regression test added (`scripts/check-cache-headers.sh`)
- [x] `caddy validate` passes
- [x] `npm run build` passes
- [x] `npm test` passes (39/39)
- [ ] Post-deploy: run `scripts/check-cache-headers.sh https://askansari.ai` — all checks should pass

## Post-merge note

Users who already have heuristically-cached HTML have no revalidation trigger, so they need one final hard refresh after this deploy; from then on deploys self-heal on the next load.